### PR TITLE
Improve PHPUnit assertion and fixtures

### DIFF
--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -17,7 +17,7 @@ class ApplicationTest extends TestCase
     private $application;
 
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->application = new Application();
     }
@@ -26,7 +26,7 @@ class ApplicationTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $fs = new Filesystem();
 
@@ -127,7 +127,7 @@ class ApplicationTest extends TestCase
     {
         $this->application->getLockFactory();
 
-        $this->assertTrue(is_dir("/tmp/console-locks"));
+        $this->assertDirectoryExists("/tmp/console-locks");
     }
 
 

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -23,7 +23,7 @@ class ExceptionTest extends TestCase
     private $output;
 
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->application = new Application();
         $this->application->setAutoExit(false);
@@ -35,7 +35,7 @@ class ExceptionTest extends TestCase
     }
 
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/ListTest.php
+++ b/tests/ListTest.php
@@ -13,13 +13,13 @@ class ListTest extends TestCase
     private $application;
 
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->application = new Application();
     }
 
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/LockTest.php
+++ b/tests/LockTest.php
@@ -21,14 +21,14 @@ class LockTest extends TestCase
     private $output;
 
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->application = new Application();
         $this->output = Mockery::mock(Output::class);
     }
 
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/ResourceInfoTest.php
+++ b/tests/ResourceInfoTest.php
@@ -22,7 +22,7 @@ class ResourceInfoTest extends TestCase
     private $output;
 
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->application = new Application();
         $this->application->setAutoExit(false);
@@ -34,7 +34,7 @@ class ResourceInfoTest extends TestCase
     }
 
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/TimeLimitTest.php
+++ b/tests/TimeLimitTest.php
@@ -23,7 +23,7 @@ class TimeLimitTest extends TestCase
     private $output;
 
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->application = new Application();
 
@@ -35,7 +35,7 @@ class TimeLimitTest extends TestCase
     }
 
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Mockery::close();
     }


### PR DESCRIPTION
# Changed log

- According to the [PHPUnit doc](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), it should be the `protected function setUp` and `protected function tearDown`.
- Using the `assertDirectoryExists` to assert expected directory is existed.